### PR TITLE
feat(common): 공통 응답 구조 지정

### DIFF
--- a/src/main/kotlin/org/bebefriends/api/common/CustomException.kt
+++ b/src/main/kotlin/org/bebefriends/api/common/CustomException.kt
@@ -1,0 +1,11 @@
+package org.bebefriends.api.common
+
+import org.springframework.http.HttpStatus
+
+/**
+ * ControllerAdvice에서 잡을 수 있도록 예외코드를 포함한 예외클래스 추가
+ */
+class CustomException(code: ExceptionCode) : RuntimeException(code.message) {
+    val code = code.name
+    val status: HttpStatus = code.status
+}

--- a/src/main/kotlin/org/bebefriends/api/common/ExceptionCode.kt
+++ b/src/main/kotlin/org/bebefriends/api/common/ExceptionCode.kt
@@ -1,0 +1,9 @@
+package org.bebefriends.api.common
+
+import org.springframework.http.HttpStatus
+
+enum class ExceptionCode(
+    val message: String, val status: HttpStatus
+) {
+    INTERNAL_ERROR("서버 내부 오류", HttpStatus.INTERNAL_SERVER_ERROR);
+}

--- a/src/main/kotlin/org/bebefriends/api/common/ExceptionData.kt
+++ b/src/main/kotlin/org/bebefriends/api/common/ExceptionData.kt
@@ -1,0 +1,12 @@
+package org.bebefriends.api.common
+
+data class ExceptionData(val code: String, val message: String) {
+    companion object {
+        fun of(e: CustomException): ExceptionData {
+            return ExceptionData(e.code, e.localizedMessage)
+        }
+        fun of(e: RuntimeException): ExceptionData {
+            return ExceptionData(ExceptionCode.INTERNAL_ERROR.name, e.localizedMessage)
+        }
+    }
+}

--- a/src/main/kotlin/org/bebefriends/api/common/GlobalControllerAdvice.kt
+++ b/src/main/kotlin/org/bebefriends/api/common/GlobalControllerAdvice.kt
@@ -1,0 +1,31 @@
+package org.bebefriends.api.common
+
+import lombok.extern.slf4j.Slf4j
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+
+@ControllerAdvice
+@Slf4j
+class GlobalControllerAdvice {
+    val logger: Logger = LoggerFactory.getLogger(GlobalControllerAdvice::class.java)
+
+    @ExceptionHandler(CustomException::class)
+    fun catchCustomException(e: CustomException) {
+        logger.info(e.code + e.localizedMessage)
+        logger.info(e.stackTraceToString())
+        val data = ExceptionData.of(e)
+        ResponseEntity.status(e.status).body(Response(data))
+    }
+
+    @ExceptionHandler(RuntimeException::class)
+    fun catchRuntimeException(e: RuntimeException) {
+        logger.error(e.localizedMessage)
+        logger.error(e.stackTraceToString())
+        val data = ExceptionData.of(e)
+        ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Response(data))
+    }
+}

--- a/src/main/kotlin/org/bebefriends/api/common/Response.kt
+++ b/src/main/kotlin/org/bebefriends/api/common/Response.kt
@@ -1,0 +1,5 @@
+package org.bebefriends.api.common
+
+data class Response<T>(val success: Boolean, val body: T) {
+    constructor(body: T) : this(body !is ExceptionData, body)
+}


### PR DESCRIPTION
## 💡 이슈
- resolve #1

## 🤩 개요
공통 응답 구조를 지정합니다.

## 🧑‍💻 작업 사항
HttpStatus는 응답의 HTTP Status로 대체합니다.
```kotlin
data class Response<T>(val success: Boolean, val body: T) {
    constructor(body: T) : this(body !is ExceptionResponse, body)
}
```
이며, body에는 예외 혹은 data가 실립니다.
예외의 구조는 다음과 같습니다.

```kotlin
data class ExceptionResponse(val code: String, val message: String) {}
```
비즈니스 로직 도중 발생시키는 예외는 CustomException의 생성자에 ExceptionCode를 전달해 생성합니다.

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.